### PR TITLE
Prevent Goomba from clipping into blocks when falling

### DIFF
--- a/app.py
+++ b/app.py
@@ -486,7 +486,7 @@ class Goomba:
             prev_rect = self.rect.copy()
             self.y += step_dy
             r = self.rect
-            for tx, ty, ch in tiles_in_aabb(tilemap, r.inflate(-6, 0)):
+            for tx, ty, ch in tiles_in_aabb(tilemap, r):
                 if ch in ('|', 'F'):
                     ch = 'X'
                 if solid(ch):


### PR DESCRIPTION
## Summary
- update the Goomba vertical collision lookup to consider the full bounding box
- prevents missing nearby solid tiles when falling off ledges, avoiding clipping into blocks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3afc17b588326a0363942499ba1ea