### PR TITLE
Add breakable blocks for big player

### DIFF
--- a/level_editor.py
+++ b/level_editor.py
@@ -20,6 +20,7 @@ PALETTE: List[Tuple[str, str, Tuple[int, int, int]]] = [
     ("^", "Stachel", (240, 90, 90)),
     ("C", "Coin", (255, 225, 90)),
     ("B", "Item-Block", (240, 190, 80)),
+    ("S", "Zerbrechlich", (200, 140, 90)),
     ("M", "Pilz", (220, 80, 80)),
     ("G", "Goomba", (190, 110, 70)),
     ("|", "Gate", (110, 210, 255)),
@@ -64,6 +65,15 @@ def draw_tile(surface: pygame.Surface, char: str, rect: pygame.Rect) -> None:
         pygame.draw.rect(surface, (90, 70, 40), mark, border_radius=4)
         dot = pygame.Rect(rect.centerx - 3, rect.y + int(rect.height * 0.72), 6, 6)
         pygame.draw.rect(surface, (90, 70, 40), dot, border_radius=3)
+        return
+
+    if char == "S":
+        pygame.draw.rect(surface, (200, 140, 90), rect, border_radius=6)
+        top = rect.copy()
+        top.height = max(4, rect.height // 4)
+        pygame.draw.rect(surface, (240, 195, 150), top, border_radius=6)
+        crack = pygame.Rect(rect.centerx - 10, rect.centery - 2, 20, 4)
+        pygame.draw.rect(surface, (120, 80, 50), crack, border_radius=2)
         return
 
     if char == "M":

--- a/level_io.py
+++ b/level_io.py
@@ -34,6 +34,11 @@ def make_default_level() -> List[str]:
     grid[y2 - 1][22] = "G"
     grid[y2 - 2][24] = "M"
 
+    # Zerbrechliche Blöcke über dem Boden
+    brick_y = ground_y - 4
+    for x in range(28, 32):
+        grid[brick_y][x] = "S"
+
     # kleiner Abgrund
     for x in range(34, 37):
         grid[ground_y][x] = " "


### PR DESCRIPTION
## Summary
- add a new breakable block type that only shatters when the player is in big form
- update rendering, collision handling, and callbacks so breakable blocks spawn particles when destroyed
- expose the new block in the default level and editor palette for quick use

## Testing
- python -m py_compile app.py level_editor.py level_io.py

------
https://chatgpt.com/codex/tasks/task_e_68d42dd07c0083269ff89cb9e6ec539e